### PR TITLE
Implement encode() and encode_len()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,23 +14,123 @@ use std::convert::AsRef;
 /// Result type.
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Returns how many bytes are needed to encode the bitfield.
-pub fn encode_len(_buf: &[u8]) -> usize {
-  unimplemented!();
-}
-
 /// Encode a bitfield.
-pub fn encode(reader: impl AsRef<Vec<u8>>) -> Vec<u8> {
-  let offset = 0;
-  encode_with_offset(reader, offset)
+pub fn encode(buf: impl AsRef<[u8]>) -> Vec<u8> {
+  let (enc, _) = encode_with_offset(&buf, 0);
+  enc
 }
 
 /// Encode a bitfield at a specific offset
 pub fn encode_with_offset(
-  _reader: impl AsRef<Vec<u8>>,
-  _offset: usize,
-) -> Vec<u8> {
-  unimplemented!();
+  buf: impl AsRef<[u8]>,
+  offset: usize,
+) -> (Vec<u8>, usize) {
+  let buf = buf.as_ref();
+  let mut len = 0u64;
+  let mut contiguous = false;
+  let mut prev_bits = 0;
+  let mut noncontiguous_bits = Vec::new();
+  let mut enc = Vec::with_capacity(encode_len_with_offset(&buf, offset));
+
+  for i in offset..buf.len() {
+    if contiguous && buf[i] == prev_bits {
+      len += 1;
+      continue;
+    } else if contiguous {
+      write_contiguous(&mut enc, len, prev_bits);
+    }
+
+    if buf[i] == 0 || buf[i] == 255 {
+      if !contiguous && i > offset {
+        write_noncontiguous(&mut enc, &mut noncontiguous_bits);
+      }
+      len = 1;
+      prev_bits = buf[i];
+      contiguous = true;
+    } else if !contiguous {
+      noncontiguous_bits.push(buf[i]);
+    } else {
+      contiguous = false;
+      noncontiguous_bits.push(buf[i]);
+    }
+  }
+
+  if contiguous {
+    write_contiguous(&mut enc, len, prev_bits);
+  } else {
+    write_noncontiguous(&mut enc, &mut noncontiguous_bits);
+  }
+
+  (enc, buf.len() - offset)
+}
+
+/// Writes a value for contiguous data to the encoded bitfield
+fn write_contiguous(enc: &mut Vec<u8>, mut len: u64, prev_bits: u8) {
+  len <<= 2;
+  len += 1;
+  if prev_bits == 255 {
+    len += 2;
+  }
+  let mut varint = vec![0u8; varint::length(len)];
+  varint::encode(len, &mut varint);
+  enc.append(&mut varint);
+}
+
+/// Writes a value for noncontiguous data to the encoded bitfield
+fn write_noncontiguous(enc: &mut Vec<u8>, noncontiguous_bits: &mut Vec<u8>) {
+  let mut len = noncontiguous_bits.len() as u64;
+  len <<= 1;
+  let mut varint = vec![0u8; varint::length(len)];
+  varint::encode(len, &mut varint);
+  enc.append(&mut varint);
+  enc.append(noncontiguous_bits);
+}
+
+/// Returns how many bytes a decoded bitfield will use.
+pub fn encode_len(buf: impl AsRef<[u8]>) -> usize {
+  encode_len_with_offset(&buf, 0)
+}
+
+/// Returns how many bytes an encoded bitfield will use, starting at a specific offset.
+pub fn encode_len_with_offset(buf: impl AsRef<[u8]>, offset: usize) -> usize {
+  let buf = buf.as_ref();
+  let mut len = 0u64;
+  let mut partial_len = 0u64;
+  let mut contiguous = false;
+  let mut prev_bits = 0;
+
+  for i in offset..buf.len() {
+    if contiguous && buf[i] == prev_bits {
+      partial_len += 1;
+      continue;
+    } else if contiguous {
+      len += varint::length(partial_len << 2) as u64;
+    }
+
+    if buf[i] == 0 || buf[i] == 255 {
+      if !contiguous && i > offset {
+        len += partial_len;
+        len += varint::length(partial_len << 1) as u64;
+      }
+      partial_len = 1;
+      prev_bits = buf[i];
+      contiguous = true;
+    } else if !contiguous {
+      partial_len += 1;
+    } else {
+      partial_len = 1;
+      contiguous = false;
+    }
+  }
+
+  if contiguous {
+    len += varint::length(partial_len << 2) as u64;
+  } else {
+    len += partial_len;
+    len += varint::length(partial_len << 1) as u64;
+  }
+
+  len as usize
 }
 
 /// Decode an encoded bitfield.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -6,11 +6,28 @@ fn should_encode_decode() {
   bits[8] = 0b00000001;
 
   let enc = bitfield_rle::encode(&bits);
-  assert_eq!(enc.len(), 6);
+  assert_eq!(enc.len(), 4);
 
   let res = bitfield_rle::decode(enc).unwrap();
 
   assert_eq!(res[8], 0b00000001);
+  assert_eq!(res, bits);
+}
+
+#[test]
+fn encode_len() {
+  let bitfield = vec![255, 255, 85, 84, 0, 0, 0, 183];
+  let len = bitfield_rle::encode_len(bitfield);
+  assert_eq!(len, 7);
+}
+
+#[test]
+fn encode() {
+  let bitfield = vec![255, 255, 85, 84, 0, 0, 0, 183];
+  let enc = bitfield_rle::encode(&bitfield);
+  let correct = vec![11, 4, 85, 84, 13, 2, 183];
+  assert_eq!(enc.len(), correct.len());
+  assert_eq!(enc, correct);
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** 🙋 feature
<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->
Previously, there was no implementation to encode. Unlike my decode PR, this code is not particularly based on the [JS implementation](https://github.com/mafintosh/bitfield-rle/blob/31a000123bc7ead667585831bc8dd21e614fe03f/index.js), but was instead rederived from the [protocol specification](https://datprotocol.github.io/how-dat-works/#have-bitfield).

The pre-existing should_encode_decode() test still fails, but once both this PR and the decode PR are merged, it will pass (I checked locally).

## Semver Changes
<!-- Which semantic version change would you recommend? -->
This should probably result in a minor semver bump.